### PR TITLE
Fixing set subscript min example.

### DIFF
--- a/Tour/subscripts.md
+++ b/Tour/subscripts.md
@@ -135,7 +135,7 @@ subscript min(_ x: yielded Int, _ y: yielded Int): Int {
 public fun main() {
   var (x, y) = (1, 2)
   min[&x, &y] = 3
-  print(min[x, y]) // 3
+  print(min[x, y]) // 2
 }
 ```
 


### PR DESCRIPTION
The current set subscript example using `min` is as follows.
```
public fun main() {
  var (x, y) = (1, 2)
  min[&x, &y] = 3
  print(min[x, y]) // 3
}
```
It states that the value to be printed is `3`, but the assignment should have set `x` to `3` which would mean that the new min value will be `y` with a value of `2`. The comment should state that `2` is printed.
